### PR TITLE
Add global-bind plugin

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# keys 0.1.1
+
+* Added `global-bind` plugin which allows usage of hotkeys while `textInput` is active.
+
 # keys 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -7,7 +7,8 @@ html_dependency_mousetrap <- function() {
     script = c(
       "mousetrap.min.js",
       "mousetrap-pause.min.js",
-      "mousetrap-record.min.js"
+      "mousetrap-record.min.js",
+      "mousetrap-global-bind.min.js"
     )
   )
 }

--- a/R/keys.R
+++ b/R/keys.R
@@ -6,6 +6,8 @@
 #' @param inputId The input slot that will be used to access the value.
 #' @param keys A character vector of keys to bind. Examples include, `command`,
 #' `command+shift+a`, `up down left right`, and more.
+#' @param global Should keys work anywhere? If TRUE, keys are triggered when
+#' inside a textInput.
 #'
 #' @examples
 #' \dontrun{
@@ -29,8 +31,8 @@
 #' }
 #'
 #' @export
-keysInput <- function(inputId, keys) {
+keysInput <- function(inputId, keys, global = FALSE) {
   htmltools::tagList(
-    keys_js(inputId, keys)
+    keys_js(inputId, keys, global)
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,13 +4,15 @@ minify <- function(x) {
 
 #' @importFrom htmltools tags
 #' @importFrom jsonlite toJSON
-keys_js <- function(id, keys) {
+keys_js <- function(id, keys, global = FALSE) {
+  if (global) global <- "Global"
+  else global <- ""
 
   x <- sprintf("$(document).on('shiny:sessioninitialized', function() {
-    Mousetrap.bind(%s, function(e, combo) {
+    Mousetrap.bind%s(%s, function(e, combo) {
       Shiny.setInputValue('%s', combo, {priority: 'event'});
     });
-  });", toJSON(keys), id)
+  });", global, toJSON(keys), id)
 
   tags$head(
     tags$script(

--- a/inst/mousetrap/mousetrap-global-bind.min.js
+++ b/inst/mousetrap/mousetrap-global-bind.min.js
@@ -1,0 +1,1 @@
+(function(a){var c={},d=a.prototype.stopCallback;a.prototype.stopCallback=function(e,b,a,f){return this.paused?!0:c[a]||c[f]?!1:d.call(this,e,b,a)};a.prototype.bindGlobal=function(a,b,d){this.bind(a,b,d);if(a instanceof Array)for(b=0;b<a.length;b++)c[a[b]]=!0;else c[a]=!0};a.init()})(Mousetrap);

--- a/man/keysInput.Rd
+++ b/man/keysInput.Rd
@@ -4,13 +4,16 @@
 \alias{keysInput}
 \title{Create a keys input control}
 \usage{
-keysInput(inputId, keys)
+keysInput(inputId, keys, global = FALSE)
 }
 \arguments{
 \item{inputId}{The input slot that will be used to access the value.}
 
 \item{keys}{A character vector of keys to bind. Examples include, \code{command},
 \code{command+shift+a}, \verb{up down left right}, and more.}
+
+\item{global}{Should keys work anywhere? If TRUE, keys are triggered when
+inside a textInput.}
 }
 \description{
 Create a key input that can be used to observe keys pressed by

--- a/man/pauseKeys.Rd
+++ b/man/pauseKeys.Rd
@@ -11,7 +11,7 @@ unpauseKey(session = shiny::getDefaultReactiveDomain())
 }
 \arguments{
 \item{session}{The \code{session} object passed to function given to
-\code{shinyServer}.}
+\code{shinyServer}. Default is \code{getDefaultReactiveDomain()}.}
 }
 \description{
 These functions allow to pause and unpause keyboard watching

--- a/man/recordKeys.Rd
+++ b/man/recordKeys.Rd
@@ -13,7 +13,7 @@ recordKeys(inputId, session = shiny::getDefaultReactiveDomain())
 \item{inputId}{The input slot that will be used to access the value.}
 
 \item{session}{The \code{session} object passed to function given to
-\code{shinyServer}.}
+\code{shinyServer}. Default is \code{getDefaultReactiveDomain()}.}
 }
 \description{
 Create a key input that can be used to record keys pressed by

--- a/man/updateKeys.Rd
+++ b/man/updateKeys.Rd
@@ -16,7 +16,7 @@ removeKeys(keys, session = shiny::getDefaultReactiveDomain())
 \code{command+shift+a}, \verb{up down left right}, and more.}
 
 \item{session}{The \code{session} object passed to function given to
-\code{shinyServer}.}
+\code{shinyServer}. Default is \code{getDefaultReactiveDomain()}.}
 }
 \description{
 Add a key binding from the server side


### PR DESCRIPTION
Allows usage of `keys` while `textInput` is active, related to #11 