### PR TITLE
Add nullOnKeyRelease option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,11 +11,12 @@ License: Apache License (>= 2)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Imports: 
     htmltools,
     shiny,
-    jsonlite
+    jsonlite,
+    glue
 URL: https://github.com/r4fun/keys
 BugReports: https://github.com/r4fun/keys/issues
 Suggests: 

--- a/R/add_key.R
+++ b/R/add_key.R
@@ -7,6 +7,7 @@
 addKeys <- function(
   inputId,
   keys,
+  nullOnKeyRelease = FALSE,
   session = shiny::getDefaultReactiveDomain()
 ){
   if (is.null(session)) alert_null_session()
@@ -17,7 +18,8 @@ addKeys <- function(
         "add_mousetrap_binding",
         list(
           id = inputId,
-          keys = x
+          keys = x,
+          nullOnKeyRelease = nullOnKeyRelease
         )
       )
     }

--- a/R/keys.R
+++ b/R/keys.R
@@ -6,8 +6,10 @@
 #' @param inputId The input slot that will be used to access the value.
 #' @param keys A character vector of keys to bind. Examples include, `command`,
 #' `command+shift+a`, `up down left right`, and more.
-#' @param global Should keys work anywhere? If TRUE, keys are triggered when
+#' @param global Should keys work anywhere? If [TRUE], keys are triggered when
 #' inside a textInput.
+#' @param nullOnKeyRelease If [TRUE], input will be set to [NULL] after keys were
+#' released.
 #'
 #' @examples
 #' \dontrun{
@@ -31,8 +33,8 @@
 #' }
 #'
 #' @export
-keysInput <- function(inputId, keys, global = FALSE) {
+keysInput <- function(inputId, keys, global = FALSE, nullOnKeyRelease = FALSE) {
   htmltools::tagList(
-    keys_js(inputId, keys, global)
+    keys_js(inputId, keys, global, nullOnKeyRelease)
   )
 }

--- a/inst/js/handlers.js
+++ b/inst/js/handlers.js
@@ -1,8 +1,17 @@
 $( document ).ready(function() {
   Shiny.addCustomMessageHandler('add_mousetrap_binding', function(arg) {
-    Mousetrap.bind(arg.keys, function() {
-      Shiny.setInputValue(arg.id, arg.keys, {priority: 'event'});
-    });
+    if (arg.nullOnKeyRelease) {
+      Mousetrap.bind(arg.keys, function() {
+        Shiny.setInputValue(arg.id, arg.keys, {priority: 'event'});
+      }, 'keydown');
+      Mousetrap.bind(arg.keys, function() {
+        Shiny.setInputValue(arg.id, null, {priority: 'event'});
+      }, 'keyup');
+    } else {
+      Mousetrap.bind(arg.keys, function() {
+        Shiny.setInputValue(arg.id, arg.keys, {priority: 'event'});
+      });
+    }
   })
   Shiny.addCustomMessageHandler('remove_mousetrap_binding', function(arg) {
     Mousetrap.unbind(arg.keys);

--- a/man/keysInput.Rd
+++ b/man/keysInput.Rd
@@ -4,7 +4,7 @@
 \alias{keysInput}
 \title{Create a keys input control}
 \usage{
-keysInput(inputId, keys, global = FALSE)
+keysInput(inputId, keys, global = FALSE, nullOnKeyRelease = FALSE)
 }
 \arguments{
 \item{inputId}{The input slot that will be used to access the value.}
@@ -12,8 +12,11 @@ keysInput(inputId, keys, global = FALSE)
 \item{keys}{A character vector of keys to bind. Examples include, \code{command},
 \code{command+shift+a}, \verb{up down left right}, and more.}
 
-\item{global}{Should keys work anywhere? If TRUE, keys are triggered when
+\item{global}{Should keys work anywhere? If \link{TRUE}, keys are triggered when
 inside a textInput.}
+
+\item{nullOnKeyRelease}{If \link{TRUE}, input will be set to \link{NULL} after keys were
+released.}
 }
 \description{
 Create a key input that can be used to observe keys pressed by

--- a/man/updateKeys.Rd
+++ b/man/updateKeys.Rd
@@ -5,7 +5,12 @@
 \alias{removeKeys}
 \title{Add a key binding from the server side}
 \usage{
-addKeys(inputId, keys, session = shiny::getDefaultReactiveDomain())
+addKeys(
+  inputId,
+  keys,
+  nullOnKeyRelease = FALSE,
+  session = shiny::getDefaultReactiveDomain()
+)
 
 removeKeys(keys, session = shiny::getDefaultReactiveDomain())
 }
@@ -14,6 +19,9 @@ removeKeys(keys, session = shiny::getDefaultReactiveDomain())
 
 \item{keys}{A character vector of keys to bind. Examples include, \code{command},
 \code{command+shift+a}, \verb{up down left right}, and more.}
+
+\item{nullOnKeyRelease}{If \link{TRUE}, input will be set to \link{NULL} after keys were
+released.}
 
 \item{session}{The \code{session} object passed to function given to
 \code{shinyServer}. Default is \code{getDefaultReactiveDomain()}.}


### PR DESCRIPTION
This pull requests adds the option `nullOnKeyRelease` to `keysInput` and `addKeys`. If this option is set, the Shiny input will be set to `NULL` after any of the bound keys is released.

This option enables to detect whether a key is pressed. Consider an actionButton whose action depends on whether `ctrl` is pressed or not. Without this option, the Shiny input is `"ctrl"` as long as `ctrl` has been pressed any time in the past. With this option, the Shiny input is only `"ctrl"` if `ctrl` is still pressed and else `NULL`.